### PR TITLE
Integrate Soroban deployment when creating projects

### DIFF
--- a/src/lib/soroban/deploy-project-token.ts
+++ b/src/lib/soroban/deploy-project-token.ts
@@ -1,0 +1,39 @@
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+export type DeployProjectTokenParams = {
+  supply: number;
+  name: string;
+  issuerPublicKey: string;
+};
+
+export type DeployProjectTokenResult = {
+  contractId: string;
+};
+
+export const deployProjectToken = async ({
+  supply,
+  name,
+  issuerPublicKey,
+}: DeployProjectTokenParams): Promise<DeployProjectTokenResult> => {
+  const wasmPath = process.env.PROJECT_TOKEN_WASM_PATH ||
+    'contracts/target/wasm32-unknown-unknown/release/project_token.wasm';
+  const network = process.env.STELLAR_NETWORK || 'testnet';
+  const source = process.env.CONTRACT_DEPLOYER || issuerPublicKey;
+
+  const cmd = `stellar contract deploy --wasm ${wasmPath} --source ${source} --network ${network}`;
+  try {
+    const { stdout } = await execAsync(cmd);
+    const lines = stdout.trim().split('\n');
+    const contractId = lines[lines.length - 1];
+    if (!/^C[A-Z0-9]{55}$/.test(contractId)) {
+      throw new Error('Invalid contract id returned');
+    }
+    return { contractId };
+  } catch (err) {
+    console.error('[soroban] Contract deployment failed:', err);
+    throw new Error('Soroban contract deployment failed');
+  }
+};

--- a/src/routes/project.routes.ts
+++ b/src/routes/project.routes.ts
@@ -3,6 +3,6 @@ import { registerProjectController } from '@/controllers/project.controller';
 
 const router = Router();
 
-router.post('/register', registerProjectController); 
+router.post('/', registerProjectController);
 
 export default router;

--- a/src/services/project.service.ts
+++ b/src/services/project.service.ts
@@ -1,5 +1,6 @@
 import db from "@/lib/db/db";
 import { uploadToIPFS } from "@/lib/ipfs/upload-to-ipfs";
+import { deployProjectToken } from "@/lib/soroban/deploy-project-token";
 
 type ProjectDTO = {
   name: string;
@@ -12,22 +13,26 @@ type ProjectDTO = {
   supply: number;
 };
 
-// Simulated contract_id (for now, it's hardcoded)
-const SIMULATED_CONTRACT_ID = "CB1234567890SIMULATEDCONTRACTIDEXAMPLE";
-
 export const registerProjectService = async (project: ProjectDTO) => {
   // 1. Upload metadata to IPFS
   const ipfsResult = await uploadToIPFS(project);
 
-  // 2. Prepare complete object to insert into DB
+  // 2. Deploy soroban contract
+  const { contractId } = await deployProjectToken({
+    supply: project.supply,
+    name: project.name,
+    issuerPublicKey: project.issuer_public_key,
+  });
+
+  // 3. Prepare object to insert into DB
   const projectWithMetadata = {
     ...project,
     ipfs_hash: ipfsResult.ipfsHash,
     ipfs_url: ipfsResult.ipfsUrl,
-    contract_id: SIMULATED_CONTRACT_ID,
+    contract_id: contractId,
   };
 
-  // 3. Insert into 'projects' table
+  // 4. Insert into 'projects' table
   const { data, error } = await db
     .from("projects")
     .insert([projectWithMetadata])


### PR DESCRIPTION
## Summary
- deploy `project_token` contract during project creation
- return contract information in the DB record
- update project creation route

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'express')*

------
https://chatgpt.com/codex/tasks/task_b_688014b5d5588330ad584ff04a59ab0a